### PR TITLE
Replace iwconfig with iw

### DIFF
--- a/client/user_script.py
+++ b/client/user_script.py
@@ -1,35 +1,46 @@
-import subprocess
 import os
+import re
+import subprocess
+
 import requests
-import json
 from dotenv import find_dotenv, load_dotenv
 
 load_dotenv((find_dotenv()))
 
-aps = [
-    "04:5F:B9:2F:56:2F",
-    "54:8A:BA:CC:80:AF",
-    "04:5F:B9:2F:7D:AF",
-    "04:5F:B9:2F:89:6F",
-    "54:8A:BA:CD:83:CF",
-    "54:8A:BA:CD:83:C0",
-    "14:16:9D:56:B4:C0",
-    "04:5F:B9:2F:78:8F",
-    "54:8A:BA:CB:AE:4F",
-    "54:8A:BA:CD:76:6F",
-    "54:8A:BA:CB:AC:AF",
-    "54:8A:BA:CD:67:4F",
-    "14:16:9D:55:92:60",
-    "04:5F:B9:2F:78:80",
+# Can be obtained via:
+# `sudo iw dev wlp5s0 scan | jc --iw-scan | jq '.[] | select(.ssid == "eduroam") | .bssid'`
+aps = {
+    "04:5f:b9:2f:56:2f",
+    "54:8a:ba:cc:80:af",
+    "04:5f:b9:2f:7d:af",
+    "04:5f:b9:2f:89:6f",
+    "54:8a:ba:cd:83:cf",
+    "54:8a:ba:cd:83:c0",
+    "14:16:9d:56:b4:c0",
+    "04:5f:b9:2f:78:8f",
+    "54:8a:ba:cb:ae:4f",
+    "54:8a:ba:cd:76:6f",
+    "54:8a:ba:cb:ac:af",
+    "54:8a:ba:cd:67:4f",
+    "14:16:9d:55:92:60",
+    "04:5f:b9:2f:78:80",
     "54:8a:ba:cd:76:60",
+}
 
-iwconfig = subprocess.Popen(('iwconfig', 'wlp0s20f3'), stdout=subprocess.PIPE)
+iw_devices = subprocess.run(["iw", "dev"], check=True, capture_output=True, text=True)
+device_match = re.search(r"Interface (?P<device_name>\w+)", iw_devices.stdout)
 
-output = subprocess.check_output(
-    ('grep', '-P', "\w\w:\w\w:\w\w:\w\w:\w\w:\w\w", '-o'), stdin=iwconfig.stdout).strip()
-iwconfig.wait()
-output = output.decode('ascii')
+iw_link = subprocess.run(
+    ["iw", "dev", device_match["device_name"], "link"],
+    check=True,
+    capture_output=True,
+    text=True,
+)
+bssid_match = re.search(r"Connected to (?P<bssid>[\w:]+)", iw_link.stdout)
 
-if (output in aps):
-    requests.post(os.environ.get('URL') + '/max_present', json={"max_token": os.environ.get('MAXTHERE_TOKEN')})
-    print(output)
+if bssid_match["bssid"] in aps:
+    print(bssid_match["bssid"])
+    requests.post(
+        os.environ["URL"] + "/max_present",
+        json={"max_token": os.environ["MAXTHERE_TOKEN"]},
+    )

--- a/client/user_script.py
+++ b/client/user_script.py
@@ -1,46 +1,35 @@
-#!/usr/bin/python3
-
+import subprocess
 import os
 import requests
 import json
 from dotenv import find_dotenv, load_dotenv
-from bs4 import BeautifulSoup
-import urllib3
-
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 load_dotenv((find_dotenv()))
 
 aps = [
-    "ap-2356-6u07",
-    "ap-2356-6u09",
-    "ap-2356-6u10b",
-    "ap-2356-6u11",
-    "ap-2356-5057",
-    "ap-2356-5052",
-    "ap-2356-6006",
-    "ap-2356-6009",
-    "ap-2356-6011",
-    "ap-2356-6013",
-    "ap-2356-6001a"
+    "04:5F:B9:2F:56:2F",
+    "54:8A:BA:CC:80:AF",
+    "04:5F:B9:2F:7D:AF",
+    "04:5F:B9:2F:89:6F",
+    "54:8A:BA:CD:83:CF",
+    "54:8A:BA:CD:83:C0",
+    "14:16:9D:56:B4:C0",
+    "04:5F:B9:2F:78:8F",
+    "54:8A:BA:CB:AE:4F",
+    "54:8A:BA:CD:76:6F",
+    "54:8A:BA:CB:AC:AF",
+    "54:8A:BA:CD:67:4F",
+    "14:16:9D:55:92:60",
+    "04:5F:B9:2F:78:80"
 ]
 
-headers = {"Accept": "application/json"}
+iwconfig = subprocess.Popen(('iwconfig', 'wlp0s20f3'), stdout=subprocess.PIPE)
 
-response = requests.request(
-    method="GET",
-    url="https://findme.rwth-aachen.de/client-info.json",
-    headers=headers,
-    verify=False,
-).json()
+output = subprocess.check_output(
+    ('grep', '-P', "\w\w:\w\w:\w\w:\w\w:\w\w:\w\w", '-o'), stdin=iwconfig.stdout).strip()
+iwconfig.wait()
+output = output.decode('ascii')
 
-if response.get("html"):
-    soup = BeautifulSoup(response.get("html"), "html.parser")
-
-    ap = soup.find("th", string="Access Point").find_next_sibling("td").string
-
-    if ap in aps:
-        requests.post(
-            os.environ.get("URL") + "/max_present",
-            json={"max_token": os.environ.get("MAXTHERE_TOKEN")},
-        )
+if (output in aps):
+    requests.post(os.environ.get('URL') + '/max_present', json={"max_token": os.environ.get('MAXTHERE_TOKEN')})
+    print(output)

--- a/client/user_script.py
+++ b/client/user_script.py
@@ -20,8 +20,8 @@ aps = [
     "54:8A:BA:CB:AC:AF",
     "54:8A:BA:CD:67:4F",
     "14:16:9D:55:92:60",
-    "04:5F:B9:2F:78:80"
-]
+    "04:5F:B9:2F:78:80",
+    "54:8a:ba:cd:76:60",
 
 iwconfig = subprocess.Popen(('iwconfig', 'wlp0s20f3'), stdout=subprocess.PIPE)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,3 @@ pycparser==2.19
 python-telegram-bot==12.1.1
 six==1.12.0
 tornado==6.0.3
-beautifulsoup4==4.12.2
-urllib3==1.26.15


### PR DESCRIPTION
Replaces findme.rwth-aachen.de in favor of Linux networking tools as they are faster and more reliable.
This not only reverts to the old version but replaces `iwconfig` used by it with the newer `iw` CLI.